### PR TITLE
fix(search): implement bbox geographic filtering

### DIFF
--- a/src/main/java/com/accountabilityatlas/searchservice/repository/SearchVideoRepository.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/repository/SearchVideoRepository.java
@@ -20,6 +20,8 @@ public interface SearchVideoRepository extends JpaRepository<SearchVideo, UUID> 
             AND (:amendments IS NULL OR v.amendments && CAST(:amendments AS VARCHAR[]))
             AND (:participants IS NULL OR v.participants && CAST(:participants AS VARCHAR[]))
             AND (:state IS NULL OR v.primary_location_state = :state)
+            AND (:minLat IS NULL OR (v.primary_location_lat BETWEEN :minLat AND :maxLat
+                 AND v.primary_location_lng BETWEEN :minLng AND :maxLng))
           ORDER BY CASE WHEN :query IS NULL OR :query = '' THEN 0 ELSE ts_rank_cd(v.search_vector, plainto_tsquery('english', :query)) END DESC,
                    v.indexed_at DESC
           """,
@@ -31,8 +33,18 @@ public interface SearchVideoRepository extends JpaRepository<SearchVideo, UUID> 
             AND (:amendments IS NULL OR v.amendments && CAST(:amendments AS VARCHAR[]))
             AND (:participants IS NULL OR v.participants && CAST(:participants AS VARCHAR[]))
             AND (:state IS NULL OR v.primary_location_state = :state)
+            AND (:minLat IS NULL OR (v.primary_location_lat BETWEEN :minLat AND :maxLat
+                 AND v.primary_location_lng BETWEEN :minLng AND :maxLng))
           """,
       nativeQuery = true)
   Page<SearchVideo> searchWithFilters(
-      String query, String amendments, String participants, String state, Pageable pageable);
+      String query,
+      String amendments,
+      String participants,
+      String state,
+      Double minLat,
+      Double maxLat,
+      Double minLng,
+      Double maxLng,
+      Pageable pageable);
 }

--- a/src/main/java/com/accountabilityatlas/searchservice/service/SearchService.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/service/SearchService.java
@@ -31,6 +31,10 @@ public class SearchService {
       Set<String> amendments,
       Set<String> participants,
       String state,
+      Double minLng,
+      Double minLat,
+      Double maxLng,
+      Double maxLat,
       Pageable pageable) {
 
     long startTime = System.currentTimeMillis();
@@ -41,7 +45,15 @@ public class SearchService {
 
     Page<SearchVideo> page =
         searchVideoRepository.searchWithFilters(
-            searchQuery, amendmentsArray, participantsArray, state, pageable);
+            searchQuery,
+            amendmentsArray,
+            participantsArray,
+            state,
+            minLat,
+            maxLat,
+            minLng,
+            maxLng,
+            pageable);
 
     long queryTime = System.currentTimeMillis() - startTime;
 

--- a/src/test/java/com/accountabilityatlas/searchservice/service/SearchServiceTest.java
+++ b/src/test/java/com/accountabilityatlas/searchservice/service/SearchServiceTest.java
@@ -52,11 +52,13 @@ class SearchServiceTest {
   void search_withQueryOnly_passesQueryToRepository() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(testVideo), pageable, 1);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    SearchResult result = searchService.search("test query", null, null, null, pageable);
+    SearchResult result =
+        searchService.search("test query", null, null, null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
@@ -65,6 +67,10 @@ class SearchServiceTest {
             amendmentsCaptor.capture(),
             participantsCaptor.capture(),
             stateCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
             eq(pageable));
 
     assertThat(queryCaptor.getValue()).isEqualTo("test query");
@@ -79,15 +85,17 @@ class SearchServiceTest {
   void search_withBlankQuery_passesNullToRepository() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search("   ", null, null, null, pageable);
+    searchService.search("   ", null, null, null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(queryCaptor.capture(), any(), any(), any(), eq(pageable));
+        .searchWithFilters(
+            queryCaptor.capture(), any(), any(), any(), any(), any(), any(), any(), eq(pageable));
 
     assertThat(queryCaptor.getValue()).isNull();
   }
@@ -96,15 +104,17 @@ class SearchServiceTest {
   void search_withNullQuery_passesNullToRepository() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, null, null, null, pageable);
+    searchService.search(null, null, null, null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(queryCaptor.capture(), any(), any(), any(), eq(pageable));
+        .searchWithFilters(
+            queryCaptor.capture(), any(), any(), any(), any(), any(), any(), any(), eq(pageable));
 
     assertThat(queryCaptor.getValue()).isNull();
   }
@@ -113,15 +123,26 @@ class SearchServiceTest {
   void search_withAmendments_convertsToPostgresArray() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, Set.of("FIRST", "FOURTH"), null, null, pageable);
+    searchService.search(
+        null, Set.of("FIRST", "FOURTH"), null, null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(any(), amendmentsCaptor.capture(), any(), any(), eq(pageable));
+        .searchWithFilters(
+            any(),
+            amendmentsCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(pageable));
 
     String amendments = amendmentsCaptor.getValue();
     assertThat(amendments).startsWith("{").contains("FIRST").contains("FOURTH").endsWith("}");
@@ -131,15 +152,26 @@ class SearchServiceTest {
   void search_withParticipants_convertsToPostgresArray() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, null, Set.of("POLICE", "CITIZEN"), null, pageable);
+    searchService.search(
+        null, null, Set.of("POLICE", "CITIZEN"), null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(any(), any(), participantsCaptor.capture(), any(), eq(pageable));
+        .searchWithFilters(
+            any(),
+            any(),
+            participantsCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(pageable));
 
     String participants = participantsCaptor.getValue();
     assertThat(participants).startsWith("{").contains("POLICE").contains("CITIZEN").endsWith("}");
@@ -149,15 +181,25 @@ class SearchServiceTest {
   void search_withEmptyAmendments_passesNullToRepository() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, Set.of(), null, null, pageable);
+    searchService.search(null, Set.of(), null, null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(any(), amendmentsCaptor.capture(), any(), any(), eq(pageable));
+        .searchWithFilters(
+            any(),
+            amendmentsCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(pageable));
 
     assertThat(amendmentsCaptor.getValue()).isNull();
   }
@@ -166,15 +208,17 @@ class SearchServiceTest {
   void search_withState_passesStateToRepository() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, null, null, "TX", pageable);
+    searchService.search(null, null, null, "TX", null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(any(), any(), any(), stateCaptor.capture(), eq(pageable));
+        .searchWithFilters(
+            any(), any(), any(), stateCaptor.capture(), any(), any(), any(), any(), eq(pageable));
 
     assertThat(stateCaptor.getValue()).isEqualTo("TX");
   }
@@ -189,11 +233,13 @@ class SearchServiceTest {
 
     Pageable page1 = PageRequest.of(1, 10);
     Page<SearchVideo> page = new PageImpl<>(List.of(video1, video2), page1, 25);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    SearchResult result = searchService.search("test", null, null, null, page1);
+    SearchResult result =
+        searchService.search("test", null, null, null, null, null, null, null, page1);
 
     // Assert
     assertThat(result.videos()).hasSize(2);
@@ -207,11 +253,13 @@ class SearchServiceTest {
   void search_recordsQueryTime() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    SearchResult result = searchService.search("test", null, null, null, pageable);
+    SearchResult result =
+        searchService.search("test", null, null, null, null, null, null, null, pageable);
 
     // Assert
     assertThat(result.queryTimeMs()).isGreaterThanOrEqualTo(0);
@@ -221,15 +269,17 @@ class SearchServiceTest {
   void search_trimsQueryWhitespace() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search("  test query  ", null, null, null, pageable);
+    searchService.search("  test query  ", null, null, null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(queryCaptor.capture(), any(), any(), any(), eq(pageable));
+        .searchWithFilters(
+            queryCaptor.capture(), any(), any(), any(), any(), any(), any(), any(), eq(pageable));
 
     assertThat(queryCaptor.getValue()).isEqualTo("test query");
   }
@@ -238,15 +288,34 @@ class SearchServiceTest {
   void search_withInvalidAmendments_filtersOutInvalidValues() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, Set.of("FIRST", "INVALID", "};DROP TABLE--"), null, null, pageable);
+    searchService.search(
+        null,
+        Set.of("FIRST", "INVALID", "};DROP TABLE--"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(any(), amendmentsCaptor.capture(), any(), any(), eq(pageable));
+        .searchWithFilters(
+            any(),
+            amendmentsCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(pageable));
 
     String amendments = amendmentsCaptor.getValue();
     assertThat(amendments).isEqualTo("{FIRST}").doesNotContain("INVALID").doesNotContain("DROP");
@@ -256,15 +325,26 @@ class SearchServiceTest {
   void search_withAllInvalidAmendments_passesNullToRepository() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, Set.of("INVALID", "ALSO_INVALID"), null, null, pageable);
+    searchService.search(
+        null, Set.of("INVALID", "ALSO_INVALID"), null, null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(any(), amendmentsCaptor.capture(), any(), any(), eq(pageable));
+        .searchWithFilters(
+            any(),
+            amendmentsCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(pageable));
 
     assertThat(amendmentsCaptor.getValue()).isNull();
   }
@@ -273,15 +353,26 @@ class SearchServiceTest {
   void search_withInvalidParticipants_filtersOutInvalidValues() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, null, Set.of("POLICE", "HACKER", "},{bad}"), null, pageable);
+    searchService.search(
+        null, null, Set.of("POLICE", "HACKER", "},{bad}"), null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(any(), any(), participantsCaptor.capture(), any(), eq(pageable));
+        .searchWithFilters(
+            any(),
+            any(),
+            participantsCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(pageable));
 
     String participants = participantsCaptor.getValue();
     assertThat(participants).isEqualTo("{POLICE}").doesNotContain("HACKER").doesNotContain("bad");
@@ -291,15 +382,26 @@ class SearchServiceTest {
   void search_withAllInvalidParticipants_passesNullToRepository() {
     // Arrange
     Page<SearchVideo> page = new PageImpl<>(List.of(), pageable, 0);
-    when(searchVideoRepository.searchWithFilters(any(), any(), any(), any(), any()))
+    when(searchVideoRepository.searchWithFilters(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(page);
 
     // Act
-    searchService.search(null, null, Set.of("NOT_A_PARTICIPANT"), null, pageable);
+    searchService.search(
+        null, null, Set.of("NOT_A_PARTICIPANT"), null, null, null, null, null, pageable);
 
     // Assert
     verify(searchVideoRepository)
-        .searchWithFilters(any(), any(), participantsCaptor.capture(), any(), eq(pageable));
+        .searchWithFilters(
+            any(),
+            any(),
+            participantsCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(pageable));
 
     assertThat(participantsCaptor.getValue()).isNull();
   }

--- a/src/test/java/com/accountabilityatlas/searchservice/web/SearchControllerTest.java
+++ b/src/test/java/com/accountabilityatlas/searchservice/web/SearchControllerTest.java
@@ -52,7 +52,8 @@ class SearchControllerTest {
   @Test
   void search_returnsOkWithEmptyResults() throws Exception {
     // Arrange
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(emptyResult);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
 
     // Act & Assert
     mockMvc
@@ -66,20 +67,23 @@ class SearchControllerTest {
   @Test
   void search_withQuery_passesQueryToService() throws Exception {
     // Arrange
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(emptyResult);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
 
     // Act
     mockMvc.perform(get("/search").param("q", "police audit")).andExpect(status().isOk());
 
     // Assert
-    verify(searchService).search(eq("police audit"), any(), any(), any(), any());
+    verify(searchService)
+        .search(eq("police audit"), any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   @Test
   void search_withResults_returnsVideoData() throws Exception {
     // Arrange
     SearchResult result = new SearchResult(List.of(testVideo), 1, 1, 0, 20, 10);
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(result);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(result);
 
     // Act & Assert
     mockMvc
@@ -98,7 +102,8 @@ class SearchControllerTest {
   @Test
   void search_withAmendmentsFilter_passesAmendmentsToService() throws Exception {
     // Arrange
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(emptyResult);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
 
     // Act
     mockMvc
@@ -106,14 +111,16 @@ class SearchControllerTest {
         .andExpect(status().isOk());
 
     // Assert
-    verify(searchService).search(any(), amendmentsCaptor.capture(), any(), any(), any());
+    verify(searchService)
+        .search(any(), amendmentsCaptor.capture(), any(), any(), any(), any(), any(), any(), any());
     assertThat(amendmentsCaptor.getValue()).containsExactlyInAnyOrder("FIRST", "FOURTH");
   }
 
   @Test
   void search_withParticipantsFilter_passesParticipantsToService() throws Exception {
     // Arrange
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(emptyResult);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
 
     // Act
     mockMvc
@@ -121,26 +128,30 @@ class SearchControllerTest {
         .andExpect(status().isOk());
 
     // Assert
-    verify(searchService).search(any(), any(), participantsCaptor.capture(), any(), any());
+    verify(searchService)
+        .search(
+            any(), any(), participantsCaptor.capture(), any(), any(), any(), any(), any(), any());
     assertThat(participantsCaptor.getValue()).containsExactlyInAnyOrder("POLICE", "CITIZEN");
   }
 
   @Test
   void search_withStateFilter_passesStateToService() throws Exception {
     // Arrange
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(emptyResult);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
 
     // Act
     mockMvc.perform(get("/search").param("state", "TX")).andExpect(status().isOk());
 
     // Assert
-    verify(searchService).search(any(), any(), any(), eq("TX"), any());
+    verify(searchService).search(any(), any(), any(), eq("TX"), any(), any(), any(), any(), any());
   }
 
   @Test
   void search_withPagination_passesPageableToService() throws Exception {
     // Arrange
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(emptyResult);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
 
     // Act
     mockMvc
@@ -148,7 +159,8 @@ class SearchControllerTest {
         .andExpect(status().isOk());
 
     // Assert
-    verify(searchService).search(any(), any(), any(), any(), pageableCaptor.capture());
+    verify(searchService)
+        .search(any(), any(), any(), any(), any(), any(), any(), any(), pageableCaptor.capture());
     Pageable pageable = pageableCaptor.getValue();
     assertThat(pageable.getPageNumber()).isEqualTo(2);
     assertThat(pageable.getPageSize()).isEqualTo(50);
@@ -157,26 +169,30 @@ class SearchControllerTest {
   @Test
   void search_withSizeOver100_capsAt100() throws Exception {
     // Arrange
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(emptyResult);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
 
     // Act
     mockMvc.perform(get("/search").param("size", "200")).andExpect(status().isOk());
 
     // Assert
-    verify(searchService).search(any(), any(), any(), any(), pageableCaptor.capture());
+    verify(searchService)
+        .search(any(), any(), any(), any(), any(), any(), any(), any(), pageableCaptor.capture());
     assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(100);
   }
 
   @Test
   void search_withDefaultPagination_usesDefaults() throws Exception {
     // Arrange
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(emptyResult);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
 
     // Act
     mockMvc.perform(get("/search")).andExpect(status().isOk());
 
     // Assert
-    verify(searchService).search(any(), any(), any(), any(), pageableCaptor.capture());
+    verify(searchService)
+        .search(any(), any(), any(), any(), any(), any(), any(), any(), pageableCaptor.capture());
     Pageable pageable = pageableCaptor.getValue();
     assertThat(pageable.getPageNumber()).isZero();
     assertThat(pageable.getPageSize()).isEqualTo(20);
@@ -187,7 +203,8 @@ class SearchControllerTest {
     // Arrange
     SearchVideo videoWithLocation = createTestVideoWithLocation();
     SearchResult result = new SearchResult(List.of(videoWithLocation), 1, 1, 0, 20, 5);
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(result);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(result);
 
     // Act & Assert
     mockMvc
@@ -204,7 +221,8 @@ class SearchControllerTest {
   void search_withNoLocation_returnsEmptyLocationsArray() throws Exception {
     // Arrange
     SearchResult result = new SearchResult(List.of(testVideo), 1, 1, 0, 20, 5);
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(result);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(result);
 
     // Act & Assert
     mockMvc
@@ -225,7 +243,8 @@ class SearchControllerTest {
     videoNullArrays.setParticipants(null);
 
     SearchResult result = new SearchResult(List.of(videoNullArrays), 1, 1, 0, 20, 5);
-    when(searchService.search(any(), any(), any(), any(), any())).thenReturn(result);
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(result);
 
     // Act & Assert
     mockMvc
@@ -235,6 +254,61 @@ class SearchControllerTest {
         .andExpect(jsonPath("$.results[0].amendments").isEmpty())
         .andExpect(jsonPath("$.results[0].participants").isArray())
         .andExpect(jsonPath("$.results[0].participants").isEmpty());
+  }
+
+  @Test
+  void search_withBbox_passesParsedCoordinatesToService() throws Exception {
+    // Arrange
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
+
+    // Act
+    mockMvc
+        .perform(get("/search").param("bbox", "-122.5,37.0,-121.0,38.0"))
+        .andExpect(status().isOk());
+
+    // Assert
+    verify(searchService)
+        .search(any(), any(), any(), any(), eq(-122.5), eq(37.0), eq(-121.0), eq(38.0), any());
+  }
+
+  @Test
+  void search_withInvalidBbox_returns400() throws Exception {
+    // Act & Assert - wrong number of values
+    mockMvc
+        .perform(get("/search").param("bbox", "-122.5,37.0,-121.0"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void search_withNonNumericBbox_returns400() throws Exception {
+    // Act & Assert - non-numeric values
+    mockMvc
+        .perform(get("/search").param("bbox", "abc,def,ghi,jkl"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void search_withNoBbox_passesNullCoordinatesToService() throws Exception {
+    // Arrange
+    when(searchService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(emptyResult);
+
+    // Act
+    mockMvc.perform(get("/search")).andExpect(status().isOk());
+
+    // Assert
+    verify(searchService)
+        .search(
+            any(),
+            any(),
+            any(),
+            any(),
+            eq((Double) null),
+            eq((Double) null),
+            eq((Double) null),
+            eq((Double) null),
+            any());
   }
 
   private SearchVideo createTestVideo() {


### PR DESCRIPTION
## Summary
- Parse `bbox` query parameter (`minLng,minLat,maxLng,maxLat`) in `SearchController` and return 400 for invalid format
- Pass 4 doubles through `SearchService` to `SearchVideoRepository`
- Add `BETWEEN` clause to both main and count native SQL queries for `primary_location_lat`/`primary_location_lng`
- When `bbox` is omitted, all parameters are null and the clause is skipped (existing behavior preserved)

## Test plan
- [x] Unit tests: bbox parsed and passed as 4 doubles to service
- [x] Unit tests: invalid bbox format returns 400
- [x] Unit tests: no bbox passes null coordinates
- [x] Unit tests: all existing controller and service tests updated for new signature
- [x] Integration tests: bbox filters to videos within bounds
- [x] Integration tests: videos outside bbox excluded
- [x] Integration tests: no bbox returns all videos
- [x] Integration tests: invalid bbox returns 400
- [x] `./gradlew spotlessApply && ./gradlew check` passes

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)