### PR TITLE
ci: add quality checks workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,19 @@
+name: Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Run checks
+        run: ./gradlew check

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -3,7 +3,7 @@ name: Lint Workflows
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:
@@ -16,4 +16,4 @@ jobs:
       - name: Run actionlint
         uses: raven-actions/actionlint@v2
         with:
-          files: ".github/workflows/*.yml"
+          files: ".github/workflows/*.yaml"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,7 @@ name: Lint OpenAPI Descriptions
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `check.yaml` workflow that runs `./gradlew check` (spotless, tests, coverage) on PRs and master pushes
- Fix `lint.yaml` push trigger: `main` → `master`
- Fix `lint-workflows.yaml` push trigger: `main` → `master`
- Fix `lint-workflows.yaml` actionlint glob: `*.yml` → `*.yaml` (all workflow files use `.yaml` extension)

Closes #12
Part of AccountabilityAtlas#38

🤖 Generated with [Claude Code](https://claude.com/claude-code)