### PR TITLE
fix: suppress SQS JavaType header for cross-service deserialization

### DIFF
--- a/src/main/java/com/accountabilityatlas/searchservice/config/SqsConfig.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/config/SqsConfig.java
@@ -1,0 +1,35 @@
+package com.accountabilityatlas.searchservice.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * SQS configuration for cross-service message deserialization.
+ *
+ * <p>By default, Spring Cloud AWS SQS adds a {@code JavaType} message attribute containing the
+ * producer's fully-qualified class name. When the consumer defines the same event in a different
+ * package, deserialization fails with {@code ClassNotFoundException}.
+ *
+ * <p>This configuration disables the {@code JavaType} header on the receiving side by providing a
+ * custom {@link SqsMessagingMessageConverter} whose {@code payloadTypeMapper} always returns null.
+ * This forces Jackson to use the {@code @SqsListener} method parameter type instead of the header
+ * value.
+ */
+@Configuration
+public class SqsConfig {
+
+  /**
+   * Custom SqsMessagingMessageConverter that ignores the JavaType header from incoming messages.
+   * This forces deserialization to use the @SqsListener method parameter type, which allows
+   * cross-service events with matching field structures but different package names.
+   */
+  @Bean
+  public SqsMessagingMessageConverter sqsMessagingMessageConverter(ObjectMapper objectMapper) {
+    SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+    converter.setObjectMapper(objectMapper);
+    converter.setPayloadTypeMapper(message -> null);
+    return converter;
+  }
+}

--- a/src/test/java/com/accountabilityatlas/searchservice/config/SqsConfigTest.java
+++ b/src/test/java/com/accountabilityatlas/searchservice/config/SqsConfigTest.java
@@ -1,0 +1,21 @@
+package com.accountabilityatlas.searchservice.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import org.junit.jupiter.api.Test;
+
+class SqsConfigTest {
+
+  private final SqsConfig sqsConfig = new SqsConfig();
+
+  @Test
+  void sqsMessagingMessageConverter_createsConverterThatIgnoresPayloadTypeHeader() {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    SqsMessagingMessageConverter converter = sqsConfig.sqsMessagingMessageConverter(objectMapper);
+
+    assertNotNull(converter);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `SqsConfig` with a custom `SqsMessagingMessageConverter` bean that ignores the `JavaType` message attribute on incoming SQS messages
- This forces Jackson to use the `@SqsListener` method parameter type for deserialization instead of the producer's fully-qualified class name
- Prevents `ClassNotFoundException` when the moderation-service sends events with its own package-qualified class names

## Details
Spring Cloud AWS SQS's `SqsTemplate` automatically adds a `JavaType` message attribute containing the producer's FQCN. When the search-service consumes from the `moderation-events` queue, it defines the same event records in a different package (`com.accountabilityatlas.searchservice.event` vs `com.accountabilityatlas.moderationservice.event`), causing deserialization to fail.

The fix follows the same pattern already applied in the moderation-service (`SqsConfig.java`). Since the search-service is consumer-only (no `SqsTemplate` producer), only the consumer-side converter bean is needed.

## Test plan
- [x] Unit test verifies the converter bean is created successfully
- [x] `./gradlew check` passes (spotless, error prone, tests, jacoco coverage)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)