### PR TITLE
fix(ci): enable JaCoCo XML report for SonarCloud coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,9 @@ tasks.withType(JavaCompile).configureEach {
 // ---- JaCoCo ----
 jacocoTestReport {
     dependsOn test
+    reports {
+        xml.required = true
+    }
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [


### PR DESCRIPTION
## Summary
- Enable JaCoCo XML report generation (`reports.xml.required = true`)
- SonarCloud requires XML reports to import coverage data; without this, coverage shows as 0%

## Test plan
- [x] `check` workflow passes
- [x] `sonar` workflow passes and SonarCloud shows coverage data

🤖 Generated with [Claude Code](https://claude.com/claude-code)