### PR TITLE
feat: add SECURITY participant type

### DIFF
--- a/docs/api-specification.yaml
+++ b/docs/api-specification.yaml
@@ -67,7 +67,7 @@ paths:
             type: array
             items:
               type: string
-              enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN]
+              enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN, SECURITY]
           style: form
           explode: true
           description: Filter by participant types
@@ -204,7 +204,7 @@ paths:
             type: array
             items:
               type: string
-              enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN]
+              enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN, SECURITY]
           style: form
           explode: true
         - name: state
@@ -268,7 +268,7 @@ components:
           type: array
           items:
             type: string
-            enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN]
+            enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN, SECURITY]
         locations:
           type: array
           items:
@@ -350,6 +350,7 @@ components:
               GOVERNMENT: 800
               CITIZEN: 1500
               BUSINESS: 200
+              SECURITY: 150
         states:
           type: object
           additionalProperties:

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -133,7 +133,7 @@ $$ LANGUAGE plpgsql;
 |-----------|------|-------------|
 | q | String | Search query text |
 | amendments | String[] | Filter by amendments (e.g., FIRST, FOURTH) |
-| participants | String[] | Filter by participants (e.g., POLICE, CITIZEN) |
+| participants | String[] | Filter by participants (e.g., POLICE, SECURITY) |
 | state | String | Filter by US state |
 | page | Int | Page number (0-indexed) |
 | size | Int | Page size (default: 20, max: 100) |
@@ -154,7 +154,7 @@ $$ LANGUAGE plpgsql;
       "channelName": "Channel Name",
       "videoDate": "2024-01-15",
       "amendments": ["FIRST", "FOURTH"],
-      "participants": ["POLICE", "CITIZEN"],
+      "participants": ["POLICE", "SECURITY"],
       "locations": [
         {
           "id": "uuid",

--- a/src/main/java/com/accountabilityatlas/searchservice/domain/Participant.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/domain/Participant.java
@@ -4,5 +4,6 @@ public enum Participant {
   POLICE,
   GOVERNMENT,
   BUSINESS,
-  CITIZEN
+  CITIZEN,
+  SECURITY
 }

--- a/src/main/resources/db/devdata/R__dev_seed_search_videos.sql
+++ b/src/main/resources/db/devdata/R__dev_seed_search_videos.sql
@@ -37,7 +37,7 @@ INSERT INTO search.search_videos (
      'Utica Michigan Police Confrontation',
      'Steve Jones confronted by Detective Sergeant during First Amendment audit.',
      'Fricn Media',
-     ARRAY['FIRST', 'FOURTH']::VARCHAR[], ARRAY['POLICE']::VARCHAR[],
+     ARRAY['FIRST', 'FOURTH']::VARCHAR[], ARRAY['POLICE', 'SECURITY']::VARCHAR[],
      '20000000-0000-0000-0000-000000000004', 'Fremont City Hall', 'Fremont', 'CA',
      37.5485, -121.9886),
 
@@ -45,7 +45,7 @@ INSERT INTO search.search_videos (
      'Pocahontas City Hall Audit',
      'First Amendment audit at Pocahontas, Arkansas city hall.',
      'The Random Patriot',
-     ARRAY['FIRST']::VARCHAR[], ARRAY['GOVERNMENT']::VARCHAR[],
+     ARRAY['FIRST']::VARCHAR[], ARRAY['GOVERNMENT', 'CITIZEN']::VARCHAR[],
      '20000000-0000-0000-0000-000000000005', 'Berkeley Post Office', 'Berkeley', 'CA',
      37.8716, -122.2727),
 


### PR DESCRIPTION
## Summary
- Add `SECURITY` to `Participant` Java enum
- Update all 3 inline enums + facet example in OpenAPI spec
- Add SECURITY and CITIZEN to dev seed data (Videos 4 and 5)
- Update `docs/technical.md`

Closes #23

Part of cross-cutting change: [AccountabilityAtlas#46](https://github.com/kelleyglenn/AccountabilityAtlas/issues/46)

## Test plan
- [x] `./gradlew check` passes (unit tests, formatting, coverage)
- [x] Full stack deployed and verified (107 API + 138 E2E tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)