### PR TITLE
feat: add filtered cluster endpoint for map

### DIFF
--- a/docs/api-specification.yaml
+++ b/docs/api-specification.yaml
@@ -136,6 +136,64 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
 
+  /search/cluster:
+    get:
+      operationId: getVideoClusters
+      summary: Get clustered video counts for map display
+      description: |
+        Returns grid-based clusters of videos within a bounding box.
+        Supports the same amendment/participant filters as the search endpoint.
+        Cluster counts represent video counts (not location counts).
+        Grid cell size is determined by zoom level: cellSize = 180 / 2^zoom.
+      tags: [Search]
+      security: []
+      parameters:
+        - name: bbox
+          in: query
+          required: true
+          schema:
+            type: string
+            pattern: "^-?\\d+\\.?\\d*,-?\\d+\\.?\\d*,-?\\d+\\.?\\d*,-?\\d+\\.?\\d*$"
+          description: "Bounding box: minLng,minLat,maxLng,maxLat"
+          example: "-125,24,-66,50"
+        - name: zoom
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 20
+          description: Map zoom level (determines cluster grid size)
+        - name: amendments
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [FIRST, SECOND, FOURTH, FIFTH]
+          style: form
+          explode: true
+          description: Filter by amendments (OR logic within)
+        - name: participants
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN, SECURITY]
+          style: form
+          explode: true
+          description: Filter by participant types
+      responses:
+        '200':
+          description: Clustered video counts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
   /search/suggest:
     get:
       operationId: getSuggestions
@@ -459,6 +517,55 @@ components:
         totalMatching:
           type: integer
           description: Total documents matching current filters
+
+    ClusterResponse:
+      type: object
+      required: [clusters, totalLocations, zoom]
+      properties:
+        clusters:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarkerCluster'
+        totalLocations:
+          type: integer
+          minimum: 0
+          description: Sum of all cluster counts
+        zoom:
+          type: integer
+          description: Echo of the requested zoom level
+
+    MarkerCluster:
+      type: object
+      required: [id, coordinates, count, bounds]
+      properties:
+        id:
+          type: string
+          description: "Deterministic cluster ID: cluster_{zoom}_{latCell}_{lngCell}"
+        coordinates:
+          $ref: '#/components/schemas/Coordinates'
+        count:
+          type: integer
+          minimum: 1
+          description: Number of videos in this cluster
+        bounds:
+          $ref: '#/components/schemas/ClusterBounds'
+
+    ClusterBounds:
+      type: object
+      required: [minLat, maxLat, minLng, maxLng]
+      properties:
+        minLat:
+          type: number
+          format: double
+        maxLat:
+          type: number
+          format: double
+        minLng:
+          type: number
+          format: double
+        maxLng:
+          type: number
+          format: double
 
     # Error schemas
     Error:

--- a/src/main/java/com/accountabilityatlas/searchservice/repository/SearchVideoRepository.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/repository/SearchVideoRepository.java
@@ -1,6 +1,7 @@
 package com.accountabilityatlas.searchservice.repository;
 
 import com.accountabilityatlas.searchservice.domain.SearchVideo;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -47,4 +48,36 @@ public interface SearchVideoRepository extends JpaRepository<SearchVideo, UUID> 
       Double minLng,
       Double maxLng,
       Pageable pageable);
+
+  @Query(
+      value =
+          """
+          SELECT
+            AVG(v.primary_location_lat) AS lat,
+            AVG(v.primary_location_lng) AS lng,
+            COUNT(*) AS count,
+            FLOOR(v.primary_location_lat / :cellSize) AS lat_cell,
+            FLOOR(v.primary_location_lng / :cellSize) AS lng_cell,
+            MIN(v.primary_location_lat) AS min_lat,
+            MAX(v.primary_location_lat) AS max_lat,
+            MIN(v.primary_location_lng) AS min_lng,
+            MAX(v.primary_location_lng) AS max_lng
+          FROM search.search_videos v
+          WHERE v.primary_location_lat IS NOT NULL
+            AND v.primary_location_lng IS NOT NULL
+            AND v.primary_location_lat BETWEEN :minLat AND :maxLat
+            AND v.primary_location_lng BETWEEN :minLng AND :maxLng
+            AND (:amendments IS NULL OR v.amendments && CAST(:amendments AS VARCHAR[]))
+            AND (:participants IS NULL OR v.participants && CAST(:participants AS VARCHAR[]))
+          GROUP BY lat_cell, lng_cell
+          """,
+      nativeQuery = true)
+  List<Object[]> findClustersInBoundingBox(
+      double minLat,
+      double maxLat,
+      double minLng,
+      double maxLng,
+      double cellSize,
+      String amendments,
+      String participants);
 }

--- a/src/main/java/com/accountabilityatlas/searchservice/service/ClusterResult.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/service/ClusterResult.java
@@ -1,0 +1,16 @@
+package com.accountabilityatlas.searchservice.service;
+
+import java.util.List;
+
+public record ClusterResult(List<Cluster> clusters, long totalLocations, int zoom) {
+
+  public record Cluster(
+      String id,
+      double latitude,
+      double longitude,
+      long count,
+      double minLat,
+      double maxLat,
+      double minLng,
+      double maxLng) {}
+}

--- a/src/main/java/com/accountabilityatlas/searchservice/service/ClusterService.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/service/ClusterService.java
@@ -1,0 +1,81 @@
+package com.accountabilityatlas.searchservice.service;
+
+import com.accountabilityatlas.searchservice.domain.Amendment;
+import com.accountabilityatlas.searchservice.domain.Participant;
+import com.accountabilityatlas.searchservice.repository.SearchVideoRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClusterService {
+
+  private static final Set<String> VALID_AMENDMENTS =
+      Arrays.stream(Amendment.values()).map(Enum::name).collect(Collectors.toSet());
+
+  private static final Set<String> VALID_PARTICIPANTS =
+      Arrays.stream(Participant.values()).map(Enum::name).collect(Collectors.toSet());
+
+  private final SearchVideoRepository searchVideoRepository;
+
+  @Transactional(readOnly = true)
+  public ClusterResult findClusters(
+      double minLat,
+      double maxLat,
+      double minLng,
+      double maxLng,
+      int zoom,
+      Set<String> amendments,
+      Set<String> participants) {
+
+    double cellSize = 180.0 / Math.pow(2, zoom);
+    String amendmentsArray = toValidatedPostgresArray(amendments, VALID_AMENDMENTS);
+    String participantsArray = toValidatedPostgresArray(participants, VALID_PARTICIPANTS);
+
+    List<Object[]> rows =
+        searchVideoRepository.findClustersInBoundingBox(
+            minLat, maxLat, minLng, maxLng, cellSize, amendmentsArray, participantsArray);
+
+    List<ClusterResult.Cluster> clusters =
+        rows.stream()
+            .map(
+                row -> {
+                  double lat = ((Number) row[0]).doubleValue();
+                  double lng = ((Number) row[1]).doubleValue();
+                  long count = ((Number) row[2]).longValue();
+                  long latCell = ((Number) row[3]).longValue();
+                  long lngCell = ((Number) row[4]).longValue();
+                  double boundsMinLat = ((Number) row[5]).doubleValue();
+                  double boundsMaxLat = ((Number) row[6]).doubleValue();
+                  double boundsMinLng = ((Number) row[7]).doubleValue();
+                  double boundsMaxLng = ((Number) row[8]).doubleValue();
+
+                  String id = "cluster_" + zoom + "_" + latCell + "_" + lngCell;
+
+                  return new ClusterResult.Cluster(
+                      id, lat, lng, count, boundsMinLat, boundsMaxLat, boundsMinLng, boundsMaxLng);
+                })
+            .toList();
+
+    long totalLocations = clusters.stream().mapToLong(ClusterResult.Cluster::count).sum();
+
+    return new ClusterResult(clusters, totalLocations, zoom);
+  }
+
+  private String toValidatedPostgresArray(Set<String> values, Set<String> validValues) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    Set<String> validated =
+        values.stream().filter(validValues::contains).collect(Collectors.toSet());
+    if (validated.isEmpty()) {
+      return null;
+    }
+    return "{" + String.join(",", validated) + "}";
+  }
+}

--- a/src/main/java/com/accountabilityatlas/searchservice/web/ClusterController.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/web/ClusterController.java
@@ -19,7 +19,7 @@ public class ClusterController {
   private final ClusterService clusterService;
 
   @GetMapping("/cluster")
-  public ResponseEntity<?> getClusters(
+  public ResponseEntity<Object> getClusters(
       @RequestParam String bbox,
       @RequestParam int zoom,
       @RequestParam(required = false) Set<String> amendments,

--- a/src/main/java/com/accountabilityatlas/searchservice/web/ClusterController.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/web/ClusterController.java
@@ -1,0 +1,80 @@
+package com.accountabilityatlas.searchservice.web;
+
+import com.accountabilityatlas.searchservice.service.ClusterResult;
+import com.accountabilityatlas.searchservice.service.ClusterService;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
+public class ClusterController {
+
+  private final ClusterService clusterService;
+
+  @GetMapping("/cluster")
+  public ResponseEntity<?> getClusters(
+      @RequestParam String bbox,
+      @RequestParam int zoom,
+      @RequestParam(required = false) Set<String> amendments,
+      @RequestParam(required = false) Set<String> participants) {
+
+    if (zoom < 1 || zoom > 20) {
+      return ResponseEntity.badRequest().body("Zoom must be between 1 and 20");
+    }
+
+    String[] parts = bbox.split(",");
+    if (parts.length != 4) {
+      return ResponseEntity.badRequest()
+          .body("Invalid bbox format. Expected: minLng,minLat,maxLng,maxLat");
+    }
+
+    double minLng;
+    double minLat;
+    double maxLng;
+    double maxLat;
+    try {
+      minLng = Double.parseDouble(parts[0]);
+      minLat = Double.parseDouble(parts[1]);
+      maxLng = Double.parseDouble(parts[2]);
+      maxLat = Double.parseDouble(parts[3]);
+    } catch (NumberFormatException e) {
+      return ResponseEntity.badRequest()
+          .body("Invalid bbox format. Expected: minLng,minLat,maxLng,maxLat");
+    }
+
+    ClusterResult result =
+        clusterService.findClusters(minLat, maxLat, minLng, maxLng, zoom, amendments, participants);
+
+    ClusterResponse response =
+        new ClusterResponse(
+            result.clusters().stream().map(this::toMarkerCluster).toList(),
+            result.totalLocations(),
+            result.zoom());
+
+    return ResponseEntity.ok(response);
+  }
+
+  private MarkerCluster toMarkerCluster(ClusterResult.Cluster cluster) {
+    return new MarkerCluster(
+        cluster.id(),
+        new Coordinates(cluster.latitude(), cluster.longitude()),
+        cluster.count(),
+        new BoundingBox(cluster.minLat(), cluster.maxLat(), cluster.minLng(), cluster.maxLng()));
+  }
+
+  // Response DTOs
+  public record ClusterResponse(List<MarkerCluster> clusters, long totalLocations, int zoom) {}
+
+  public record MarkerCluster(String id, Coordinates coordinates, long count, BoundingBox bounds) {}
+
+  public record Coordinates(double latitude, double longitude) {}
+
+  public record BoundingBox(double minLat, double maxLat, double minLng, double maxLng) {}
+}

--- a/src/test/java/com/accountabilityatlas/searchservice/integration/SearchIntegrationTest.java
+++ b/src/test/java/com/accountabilityatlas/searchservice/integration/SearchIntegrationTest.java
@@ -242,6 +242,99 @@ class SearchIntegrationTest {
     mockMvc.perform(get("/search").param("bbox", "invalid")).andExpect(status().isBadRequest());
   }
 
+  // --- Cluster endpoint tests ---
+
+  @Test
+  void cluster_returnsVideosGroupedByProximity() throws Exception {
+    // Two videos near SF, one near LA
+    SearchVideo sf1 = createVideoWithLocation("SF Video 1", "Description", 37.7749, -122.4194);
+    SearchVideo sf2 = createVideoWithLocation("SF Video 2", "Description", 37.7850, -122.4094);
+    SearchVideo la = createVideoWithLocation("LA Video", "Description", 34.0522, -118.2437);
+    searchVideoRepository.saveAll(java.util.List.of(sf1, sf2, la));
+
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-125,24,-66,50").param("zoom", "7"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.clusters").isArray())
+        .andExpect(jsonPath("$.totalLocations").value(3))
+        .andExpect(jsonPath("$.zoom").value(7));
+  }
+
+  @Test
+  void cluster_withAmendmentFilter_excludesNonMatchingVideos() throws Exception {
+    SearchVideo firstAmendment =
+        createVideoWithLocationAndAmendments("1A Video", 37.7749, -122.4194, "FIRST");
+    SearchVideo fourthAmendment =
+        createVideoWithLocationAndAmendments("4A Video", 37.7850, -122.4094, "FOURTH");
+    searchVideoRepository.saveAll(java.util.List.of(firstAmendment, fourthAmendment));
+
+    mockMvc
+        .perform(
+            get("/search/cluster")
+                .param("bbox", "-125,24,-66,50")
+                .param("zoom", "5")
+                .param("amendments", "FIRST"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalLocations").value(1));
+  }
+
+  @Test
+  void cluster_withParticipantFilter_excludesNonMatchingVideos() throws Exception {
+    SearchVideo policeVideo =
+        createVideoWithLocationAndParticipants("Police Video", 37.7749, -122.4194, "POLICE");
+    SearchVideo govVideo =
+        createVideoWithLocationAndParticipants("Gov Video", 37.7850, -122.4094, "GOVERNMENT");
+    searchVideoRepository.saveAll(java.util.List.of(policeVideo, govVideo));
+
+    mockMvc
+        .perform(
+            get("/search/cluster")
+                .param("bbox", "-125,24,-66,50")
+                .param("zoom", "5")
+                .param("participants", "POLICE"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalLocations").value(1));
+  }
+
+  @Test
+  void cluster_withNoVideosInBbox_returnsEmptyArray() throws Exception {
+    SearchVideo video = createVideoWithLocation("SF Video", "Description", 37.7749, -122.4194);
+    searchVideoRepository.save(video);
+
+    // Middle of Pacific Ocean
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "170,10,175,15").param("zoom", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.clusters").isArray())
+        .andExpect(jsonPath("$.clusters").isEmpty())
+        .andExpect(jsonPath("$.totalLocations").value(0));
+  }
+
+  @Test
+  void cluster_withInvalidBbox_returns400() throws Exception {
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "invalid").param("zoom", "5"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void cluster_clusterHasExpectedFields() throws Exception {
+    SearchVideo video = createVideoWithLocation("SF Video", "Description", 37.7749, -122.4194);
+    searchVideoRepository.save(video);
+
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-125,24,-66,50").param("zoom", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.clusters[0].id").isString())
+        .andExpect(jsonPath("$.clusters[0].coordinates.latitude").isNumber())
+        .andExpect(jsonPath("$.clusters[0].coordinates.longitude").isNumber())
+        .andExpect(jsonPath("$.clusters[0].count").isNumber())
+        .andExpect(jsonPath("$.clusters[0].bounds.minLat").isNumber())
+        .andExpect(jsonPath("$.clusters[0].bounds.maxLat").isNumber())
+        .andExpect(jsonPath("$.clusters[0].bounds.minLng").isNumber())
+        .andExpect(jsonPath("$.clusters[0].bounds.maxLng").isNumber());
+  }
+
   @Test
   void actuatorHealth_isAccessible() throws Exception {
     mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
@@ -266,6 +359,22 @@ class SearchIntegrationTest {
   private SearchVideo createVideoWithLocation(
       String title, String description, double lat, double lng) {
     SearchVideo video = createVideo(title, description, new String[] {}, new String[] {}, null);
+    video.setPrimaryLocationLat(lat);
+    video.setPrimaryLocationLng(lng);
+    return video;
+  }
+
+  private SearchVideo createVideoWithLocationAndAmendments(
+      String title, double lat, double lng, String... amendments) {
+    SearchVideo video = createVideo(title, "Description", amendments, new String[] {}, null);
+    video.setPrimaryLocationLat(lat);
+    video.setPrimaryLocationLng(lng);
+    return video;
+  }
+
+  private SearchVideo createVideoWithLocationAndParticipants(
+      String title, double lat, double lng, String... participants) {
+    SearchVideo video = createVideo(title, "Description", new String[] {}, participants, null);
     video.setPrimaryLocationLat(lat);
     video.setPrimaryLocationLng(lng);
     return video;

--- a/src/test/java/com/accountabilityatlas/searchservice/service/ClusterServiceTest.java
+++ b/src/test/java/com/accountabilityatlas/searchservice/service/ClusterServiceTest.java
@@ -26,7 +26,8 @@ class ClusterServiceTest {
   @InjectMocks private ClusterService clusterService;
 
   @Test
-  void findClusters_calculatesCorrectCellSizeForZoom3() {
+  void findClusters_withZoom3_calculatesCellSizeOf22Point5() {
+    // Arrange
     when(searchVideoRepository.findClustersInBoundingBox(
             anyDouble(),
             anyDouble(),
@@ -37,16 +38,18 @@ class ClusterServiceTest {
             anyString()))
         .thenReturn(List.of());
 
-    // cellSize = 180.0 / pow(2, 3) = 180.0 / 8 = 22.5
+    // Act
     clusterService.findClusters(24, 50, -125, -66, 3, Set.of("FIRST"), Set.of("POLICE"));
 
+    // Assert — cellSize = 180.0 / pow(2, 3) = 180.0 / 8 = 22.5
     verify(searchVideoRepository)
         .findClustersInBoundingBox(
             eq(24.0), eq(50.0), eq(-125.0), eq(-66.0), eq(22.5), anyString(), anyString());
   }
 
   @Test
-  void findClusters_calculatesCorrectCellSizeForZoom8() {
+  void findClusters_withZoom8_calculatesCellSizeOf0Point703125() {
+    // Arrange
     when(searchVideoRepository.findClustersInBoundingBox(
             anyDouble(),
             anyDouble(),
@@ -57,22 +60,26 @@ class ClusterServiceTest {
             anyString()))
         .thenReturn(List.of());
 
-    // cellSize = 180.0 / pow(2, 8) = 180.0 / 256 = 0.703125
+    // Act
     clusterService.findClusters(24, 50, -125, -66, 8, Set.of("FIRST"), Set.of("POLICE"));
 
+    // Assert — cellSize = 180.0 / pow(2, 8) = 180.0 / 256 = 0.703125
     verify(searchVideoRepository)
         .findClustersInBoundingBox(
             eq(24.0), eq(50.0), eq(-125.0), eq(-66.0), eq(0.703125), anyString(), anyString());
   }
 
   @Test
-  void findClusters_validatesAmendments() {
+  void findClusters_withInvalidAmendment_filtersToOnlyValidValues() {
+    // Arrange
     when(searchVideoRepository.findClustersInBoundingBox(
             anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyString(), isNull()))
         .thenReturn(List.of());
 
+    // Act
     clusterService.findClusters(24, 50, -125, -66, 5, Set.of("FIRST", "INVALID"), null);
 
+    // Assert
     verify(searchVideoRepository)
         .findClustersInBoundingBox(
             anyDouble(),
@@ -85,13 +92,16 @@ class ClusterServiceTest {
   }
 
   @Test
-  void findClusters_validatesParticipants() {
+  void findClusters_withInvalidParticipant_filtersToOnlyValidValues() {
+    // Arrange
     when(searchVideoRepository.findClustersInBoundingBox(
             anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), anyString()))
         .thenReturn(List.of());
 
+    // Act
     clusterService.findClusters(24, 50, -125, -66, 5, null, Set.of("POLICE", "INVALID"));
 
+    // Assert
     verify(searchVideoRepository)
         .findClustersInBoundingBox(
             anyDouble(),
@@ -104,20 +114,24 @@ class ClusterServiceTest {
   }
 
   @Test
-  void findClusters_nullFiltersPassedAsNull() {
+  void findClusters_withNullFilters_passesNullToRepository() {
+    // Arrange
     when(searchVideoRepository.findClustersInBoundingBox(
             anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), isNull()))
         .thenReturn(List.of());
 
+    // Act
     clusterService.findClusters(24, 50, -125, -66, 5, null, null);
 
+    // Assert
     verify(searchVideoRepository)
         .findClustersInBoundingBox(
             anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), isNull());
   }
 
   @Test
-  void findClusters_convertsRawResultsToDtos() {
+  void findClusters_withQueryResults_convertsRawRowsToDtos() {
+    // Arrange
     Object[] row = new Object[] {37.5, -122.0, 10L, 6L, -21L, 37.0, 38.0, -123.0, -121.0};
     List<Object[]> rows = new java.util.ArrayList<>();
     rows.add(row);
@@ -125,8 +139,10 @@ class ClusterServiceTest {
             anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), isNull()))
         .thenReturn(rows);
 
+    // Act
     ClusterResult result = clusterService.findClusters(24, 50, -125, -66, 5, null, null);
 
+    // Assert
     assertThat(result.clusters()).hasSize(1);
     ClusterResult.Cluster cluster = result.clusters().getFirst();
     assertThat(cluster.id()).isEqualTo("cluster_5_6_-21");
@@ -140,7 +156,8 @@ class ClusterServiceTest {
   }
 
   @Test
-  void findClusters_calculatesTotalLocations() {
+  void findClusters_withMultipleClusters_sumsTotalLocations() {
+    // Arrange
     Object[] row1 = new Object[] {37.5, -122.0, 10L, 6L, -21L, 37.0, 38.0, -123.0, -121.0};
     Object[] row2 = new Object[] {34.0, -118.0, 5L, 5L, -20L, 33.5, 34.5, -118.5, -117.5};
     List<Object[]> rows = new java.util.ArrayList<>();
@@ -150,8 +167,10 @@ class ClusterServiceTest {
             anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), isNull()))
         .thenReturn(rows);
 
+    // Act
     ClusterResult result = clusterService.findClusters(24, 50, -125, -66, 5, null, null);
 
+    // Assert
     assertThat(result.totalLocations()).isEqualTo(15);
     assertThat(result.zoom()).isEqualTo(5);
   }

--- a/src/test/java/com/accountabilityatlas/searchservice/service/ClusterServiceTest.java
+++ b/src/test/java/com/accountabilityatlas/searchservice/service/ClusterServiceTest.java
@@ -1,0 +1,158 @@
+package com.accountabilityatlas.searchservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.accountabilityatlas.searchservice.repository.SearchVideoRepository;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterServiceTest {
+
+  @Mock private SearchVideoRepository searchVideoRepository;
+
+  @InjectMocks private ClusterService clusterService;
+
+  @Test
+  void findClusters_calculatesCorrectCellSizeForZoom3() {
+    when(searchVideoRepository.findClustersInBoundingBox(
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyString(),
+            anyString()))
+        .thenReturn(List.of());
+
+    // cellSize = 180.0 / pow(2, 3) = 180.0 / 8 = 22.5
+    clusterService.findClusters(24, 50, -125, -66, 3, Set.of("FIRST"), Set.of("POLICE"));
+
+    verify(searchVideoRepository)
+        .findClustersInBoundingBox(
+            eq(24.0), eq(50.0), eq(-125.0), eq(-66.0), eq(22.5), anyString(), anyString());
+  }
+
+  @Test
+  void findClusters_calculatesCorrectCellSizeForZoom8() {
+    when(searchVideoRepository.findClustersInBoundingBox(
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyString(),
+            anyString()))
+        .thenReturn(List.of());
+
+    // cellSize = 180.0 / pow(2, 8) = 180.0 / 256 = 0.703125
+    clusterService.findClusters(24, 50, -125, -66, 8, Set.of("FIRST"), Set.of("POLICE"));
+
+    verify(searchVideoRepository)
+        .findClustersInBoundingBox(
+            eq(24.0), eq(50.0), eq(-125.0), eq(-66.0), eq(0.703125), anyString(), anyString());
+  }
+
+  @Test
+  void findClusters_validatesAmendments() {
+    when(searchVideoRepository.findClustersInBoundingBox(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyString(), isNull()))
+        .thenReturn(List.of());
+
+    clusterService.findClusters(24, 50, -125, -66, 5, Set.of("FIRST", "INVALID"), null);
+
+    verify(searchVideoRepository)
+        .findClustersInBoundingBox(
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            eq("{FIRST}"),
+            isNull());
+  }
+
+  @Test
+  void findClusters_validatesParticipants() {
+    when(searchVideoRepository.findClustersInBoundingBox(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), anyString()))
+        .thenReturn(List.of());
+
+    clusterService.findClusters(24, 50, -125, -66, 5, null, Set.of("POLICE", "INVALID"));
+
+    verify(searchVideoRepository)
+        .findClustersInBoundingBox(
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            isNull(),
+            eq("{POLICE}"));
+  }
+
+  @Test
+  void findClusters_nullFiltersPassedAsNull() {
+    when(searchVideoRepository.findClustersInBoundingBox(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), isNull()))
+        .thenReturn(List.of());
+
+    clusterService.findClusters(24, 50, -125, -66, 5, null, null);
+
+    verify(searchVideoRepository)
+        .findClustersInBoundingBox(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), isNull());
+  }
+
+  @Test
+  void findClusters_convertsRawResultsToDtos() {
+    Object[] row = new Object[] {37.5, -122.0, 10L, 6L, -21L, 37.0, 38.0, -123.0, -121.0};
+    List<Object[]> rows = new java.util.ArrayList<>();
+    rows.add(row);
+    when(searchVideoRepository.findClustersInBoundingBox(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), isNull()))
+        .thenReturn(rows);
+
+    ClusterResult result = clusterService.findClusters(24, 50, -125, -66, 5, null, null);
+
+    assertThat(result.clusters()).hasSize(1);
+    ClusterResult.Cluster cluster = result.clusters().getFirst();
+    assertThat(cluster.id()).isEqualTo("cluster_5_6_-21");
+    assertThat(cluster.latitude()).isCloseTo(37.5, within(0.001));
+    assertThat(cluster.longitude()).isCloseTo(-122.0, within(0.001));
+    assertThat(cluster.count()).isEqualTo(10);
+    assertThat(cluster.minLat()).isCloseTo(37.0, within(0.001));
+    assertThat(cluster.maxLat()).isCloseTo(38.0, within(0.001));
+    assertThat(cluster.minLng()).isCloseTo(-123.0, within(0.001));
+    assertThat(cluster.maxLng()).isCloseTo(-121.0, within(0.001));
+  }
+
+  @Test
+  void findClusters_calculatesTotalLocations() {
+    Object[] row1 = new Object[] {37.5, -122.0, 10L, 6L, -21L, 37.0, 38.0, -123.0, -121.0};
+    Object[] row2 = new Object[] {34.0, -118.0, 5L, 5L, -20L, 33.5, 34.5, -118.5, -117.5};
+    List<Object[]> rows = new java.util.ArrayList<>();
+    rows.add(row1);
+    rows.add(row2);
+    when(searchVideoRepository.findClustersInBoundingBox(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), isNull(), isNull()))
+        .thenReturn(rows);
+
+    ClusterResult result = clusterService.findClusters(24, 50, -125, -66, 5, null, null);
+
+    assertThat(result.totalLocations()).isEqualTo(15);
+    assertThat(result.zoom()).isEqualTo(5);
+  }
+}

--- a/src/test/java/com/accountabilityatlas/searchservice/web/ClusterControllerTest.java
+++ b/src/test/java/com/accountabilityatlas/searchservice/web/ClusterControllerTest.java
@@ -1,0 +1,192 @@
+package com.accountabilityatlas.searchservice.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.accountabilityatlas.searchservice.config.SecurityConfig;
+import com.accountabilityatlas.searchservice.service.ClusterResult;
+import com.accountabilityatlas.searchservice.service.ClusterService;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ClusterController.class)
+@Import(SecurityConfig.class)
+class ClusterControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private ClusterService clusterService;
+
+  @Captor private ArgumentCaptor<Set<String>> amendmentsCaptor;
+  @Captor private ArgumentCaptor<Set<String>> participantsCaptor;
+
+  private ClusterResult emptyResult;
+  private ClusterResult singleClusterResult;
+
+  @BeforeEach
+  void setUp() {
+    emptyResult = new ClusterResult(List.of(), 0, 5);
+    singleClusterResult =
+        new ClusterResult(
+            List.of(
+                new ClusterResult.Cluster(
+                    "cluster_5_1_-3", 37.5, -122.0, 10, 37.0, 38.0, -123.0, -121.0)),
+            10,
+            5);
+  }
+
+  @Test
+  void cluster_withNoFilters_returnsClusters() throws Exception {
+    when(clusterService.findClusters(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyInt(), any(), any()))
+        .thenReturn(singleClusterResult);
+
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-125,24,-66,50").param("zoom", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.clusters").isArray())
+        .andExpect(jsonPath("$.clusters[0].id").value("cluster_5_1_-3"))
+        .andExpect(jsonPath("$.clusters[0].coordinates.latitude").value(37.5))
+        .andExpect(jsonPath("$.clusters[0].coordinates.longitude").value(-122.0))
+        .andExpect(jsonPath("$.clusters[0].count").value(10))
+        .andExpect(jsonPath("$.clusters[0].bounds.minLat").value(37.0))
+        .andExpect(jsonPath("$.clusters[0].bounds.maxLat").value(38.0))
+        .andExpect(jsonPath("$.totalLocations").value(10))
+        .andExpect(jsonPath("$.zoom").value(5));
+  }
+
+  @Test
+  void cluster_withAmendmentsFilter_passesToService() throws Exception {
+    when(clusterService.findClusters(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyInt(), any(), any()))
+        .thenReturn(emptyResult);
+
+    mockMvc
+        .perform(
+            get("/search/cluster")
+                .param("bbox", "-125,24,-66,50")
+                .param("zoom", "5")
+                .param("amendments", "FIRST")
+                .param("amendments", "FOURTH"))
+        .andExpect(status().isOk());
+
+    verify(clusterService)
+        .findClusters(
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyInt(),
+            amendmentsCaptor.capture(),
+            any());
+    assertThat(amendmentsCaptor.getValue()).containsExactlyInAnyOrder("FIRST", "FOURTH");
+  }
+
+  @Test
+  void cluster_withParticipantsFilter_passesToService() throws Exception {
+    when(clusterService.findClusters(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyInt(), any(), any()))
+        .thenReturn(emptyResult);
+
+    mockMvc
+        .perform(
+            get("/search/cluster")
+                .param("bbox", "-125,24,-66,50")
+                .param("zoom", "5")
+                .param("participants", "POLICE"))
+        .andExpect(status().isOk());
+
+    verify(clusterService)
+        .findClusters(
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyDouble(),
+            anyInt(),
+            any(),
+            participantsCaptor.capture());
+    assertThat(participantsCaptor.getValue()).containsExactlyInAnyOrder("POLICE");
+  }
+
+  @Test
+  void cluster_withInvalidBbox_returns400() throws Exception {
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "invalid").param("zoom", "5"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void cluster_withWrongBboxPartCount_returns400() throws Exception {
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-125,24,-66").param("zoom", "5"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void cluster_missingBbox_returns400() throws Exception {
+    mockMvc.perform(get("/search/cluster").param("zoom", "5")).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void cluster_missingZoom_returns400() throws Exception {
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-125,24,-66,50"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void cluster_withZoomOutOfRange_returns400() throws Exception {
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-125,24,-66,50").param("zoom", "0"))
+        .andExpect(status().isBadRequest());
+
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-125,24,-66,50").param("zoom", "21"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void cluster_parsesBboxCorrectly() throws Exception {
+    when(clusterService.findClusters(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyInt(), any(), any()))
+        .thenReturn(emptyResult);
+
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-122.5,37.0,-121.0,38.0").param("zoom", "8"))
+        .andExpect(status().isOk());
+
+    // bbox format: minLng,minLat,maxLng,maxLat -> findClusters(minLat, maxLat, minLng, maxLng, ...)
+    verify(clusterService)
+        .findClusters(eq(37.0), eq(38.0), eq(-122.5), eq(-121.0), eq(8), any(), any());
+  }
+
+  @Test
+  void cluster_emptyResult_returnsEmptyArray() throws Exception {
+    when(clusterService.findClusters(
+            anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyInt(), any(), any()))
+        .thenReturn(emptyResult);
+
+    mockMvc
+        .perform(get("/search/cluster").param("bbox", "-125,24,-66,50").param("zoom", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.clusters").isArray())
+        .andExpect(jsonPath("$.clusters").isEmpty())
+        .andExpect(jsonPath("$.totalLocations").value(0));
+  }
+}


### PR DESCRIPTION
## Summary

- Add `GET /search/cluster` endpoint with grid-based video clustering
- Support `bbox` (required), `zoom` (required), `amendments` (optional), `participants` (optional) parameters
- Grid cell size calculated from zoom level: `cellSize = 180 / 2^zoom`
- Cluster counts represent video counts (not location counts)
- Response format compatible with existing web-app cluster display
- Reuse PostgreSQL array overlap (`&&`) filter pattern from existing search endpoint

## Files Changed

| File | Change |
|------|--------|
| `ClusterController.java` | New REST controller with bbox parsing, response DTOs |
| `ClusterService.java` | Business logic: cell size calc, array validation, DTO mapping |
| `ClusterResult.java` | Result record with cluster data |
| `SearchVideoRepository.java` | New `findClustersInBoundingBox` native query with grid grouping |
| `api-specification.yaml` | OpenAPI spec for `/search/cluster` endpoint |
| `ClusterControllerTest.java` | WebMvcTest: params, validation, response shape |
| `ClusterServiceTest.java` | Unit test: cell size, validation, DTO conversion |
| `SearchIntegrationTest.java` | Integration tests with TestContainers |

## Test plan

- [x] `ClusterControllerTest` — 9 tests (params, validation, bbox parsing, response shape)
- [x] `ClusterServiceTest` — 7 tests (cell size calc, enum validation, DTO mapping)
- [x] `SearchIntegrationTest` — 6 new tests (grouped clusters, amendment/participant filters, empty bbox, validation)
- [x] All existing search tests continue to pass
- [x] Full integration test suite: 8/8 cluster API tests pass

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)