### PR TITLE
fix: add FOURTEENTH to Amendment enum

### DIFF
--- a/src/main/java/com/accountabilityatlas/searchservice/domain/Amendment.java
+++ b/src/main/java/com/accountabilityatlas/searchservice/domain/Amendment.java
@@ -4,5 +4,6 @@ public enum Amendment {
   FIRST,
   SECOND,
   FOURTH,
-  FIFTH
+  FIFTH,
+  FOURTEENTH
 }


### PR DESCRIPTION
## Summary
- Added `FOURTEENTH` to the `Amendment` enum in the search-service, matching the video-service and web-app

The 14th Amendment filter was silently ignored because `FOURTEENTH` wasn't in the search-service's enum. The validation in `SearchService.toValidatedPostgresArray()` stripped it as invalid, causing the query to run with no amendment filter at all.

## Test plan
- [x] All existing unit and integration tests pass
- [x] Full quality gate (`check`) passes
- [ ] After deploy, click "14th Amendment" filter on map page and verify only 14th amendment videos appear

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)